### PR TITLE
feat: add node overcommit annotation consts

### DIFF
--- a/pkg/consts/overcommit.go
+++ b/pkg/consts/overcommit.go
@@ -1,0 +1,28 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package consts
+
+// const variables for node annotations about overcommit ratio
+const (
+	NodeAnnotationCPUOvercommitRatioKey    = "katalyst.kubewharf.io/cpu_overcommit_ratio"
+	NodeAnnotationMemoryOvercommitRatioKey = "katalyst.kubewharf.io/memory_overcommit_ratio"
+
+	NodeAnnotationOriginalCapacityCPUKey       = "katalyst.kubewharf.io/original_capacity_cpu"
+	NodeAnnotationOriginalCapacityMemoryKey    = "katalyst.kubewharf.io/original_capacity_memory"
+	NodeAnnotationOriginalAllocatableCPUKey    = "katalyst.kubewharf.io/original_allocatable_cpu"
+	NodeAnnotationOriginalAllocatableMemoryKey = "katalyst.kubewharf.io/original_allocatable_memory"
+)


### PR DESCRIPTION
#### What type of PR is this?
Features

#### What this PR does / why we need it:
add node overcommit annotation key consts for
1) record node CPU and memory overcommit ratio
the annotation value will be used to calculate node virtual capacity and allocatable in mutating webhook
2) record capacity and allocatable before overcommited

