### PR TITLE
add pod_cpu_cpi in custom metric

### DIFF
--- a/pkg/metric/pod/pod.go
+++ b/pkg/metric/pod/pod.go
@@ -23,6 +23,7 @@ package pod
 const (
 	CustomMetricPodCPULoad1Min = "pod_cpu_load_1min"
 	CustomMetricPodCPUUsage    = "pod_cpu_usage"
+	CustomMetricPodCPUCPI      = "pod_cpu_cpi"
 )
 
 const (


### PR DESCRIPTION
#### What type of PR is this?
<!--
Features/Bug fixes/Enhancements
-->

#### What this PR does / why we need it:
Adding pod_cpu_cpi in custom metrics. pod_cpu_cpi could be an indicator during resource management.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:
