### PR TITLE
enhancement(kcmas): metric selector key group by

### DIFF
--- a/pkg/metric/consts.go
+++ b/pkg/metric/consts.go
@@ -30,3 +30,10 @@ const (
 	AggregateFunctionP90    = "_agg_p90"
 	AggregateFunctionLatest = "_agg_latest"
 )
+
+// MetricSelectorKeyGroupBy is the key of groupBy in metric selector. It's value should be a set of the real metric
+// selector keys which will be used to group the metrics. MetricSelectorKeyGroupBy should only be used in aggregated
+// metrics.
+// For example, if we want to get the max cpu load of each container,we can query the `pod_cpu_load_1min_agg_max` with
+// following metric selector: `groupBy=container`.
+const MetricSelectorKeyGroupBy = "groupBy"


### PR DESCRIPTION
#### What type of PR is this?
Enhancements

#### What this PR does / why we need it:
This pr adds a const `MetricSelectorKeyGroupBy`. It will be used when clients want to query grouped aggregated metrics.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:
