### PR TITLE
fix(config): make EnabledStrategies field optional in StrategyGroupStatus

### DIFF
--- a/config/crd/bases/config.katalyst.kubewharf.io_strategygroups.yaml
+++ b/config/crd/bases/config.katalyst.kubewharf.io_strategygroups.yaml
@@ -228,8 +228,6 @@ spec:
                   this config.
                 format: int32
                 type: integer
-            required:
-            - enabledStrategies
             type: object
         type: object
     served: true

--- a/pkg/apis/config/v1alpha1/strategygroup.go
+++ b/pkg/apis/config/v1alpha1/strategygroup.go
@@ -63,7 +63,8 @@ type StrategyGroupStatus struct {
 	GenericConfigStatus `json:",inline"`
 
 	// EnabledStrategies are strategies enabled in this group
-	EnabledStrategies []Strategy `json:"enabledStrategies"`
+	// +optional
+	EnabledStrategies []Strategy `json:"enabledStrategies,omitempty"`
 }
 
 type Strategy struct {

--- a/pkg/consts/resource.go
+++ b/pkg/consts/resource.go
@@ -36,6 +36,6 @@ const (
 	// (to replace with the default name)
 	ResourceAnnotationKeyResourceIdentifier = "katalyst.kubewharf.io/resource_identifier"
 
-	// ResourceAnnotationKeyResourceIdentifier nominated the key indicating net namespace name of the NIC
+	// ResourceAnnotationKeyNICNetNSName nominated the key indicating net namespace name of the NIC
 	ResourceAnnotationKeyNICNetNSName = "katalyst.kubewharf.io/netns_name"
 )


### PR DESCRIPTION
#### What type of PR is this?
<!--
Features/Bug fixes/Enhancements
-->
Bug fixes
#### What this PR does / why we need it:
Add omitempty tag to EnabledStrategies field and remove it from required fields in CRD Fix incorrect comment for ResourceAnnotationKeyNICNetNSName
#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:
