### PR TITLE
feat(aqc): add numa level reclaim reserve config

### DIFF
--- a/config/crd/bases/config.katalyst.kubewharf.io_adminqosconfigurations.yaml
+++ b/config/crd/bases/config.katalyst.kubewharf.io_adminqosconfigurations.yaml
@@ -786,6 +786,30 @@ spec:
                           MinReclaimedResourceForReport.
                           For example, {"cpu": 4, "memory": 5Gi}.
                         type: object
+                      numaMinReclaimedResourceForAllocate:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          NumaMinReclaimedResourceForAllocate is a resource reserved at numa level for reclaimed_cores pods，these resources will not be used
+                          by shared_cores pods.
+                          For example, {"cpu": 2, "memory": 0Gi}.
+                        type: object
+                      numaMinReclaimedResourceRatioForAllocate:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          NumaMinReclaimedResourceRatioForAllocate is a resource reserved ratio at numa level for reclaimed_cores pods，these resources will not be used
+                          by shared_cores pods.
+                          For example, {"cpu": 0.1, "memory": 0.2}.
+                        type: object
                       reservedResourceForAllocate:
                         additionalProperties:
                           anyOf:

--- a/pkg/apis/config/v1alpha1/adminqos.go
+++ b/pkg/apis/config/v1alpha1/adminqos.go
@@ -127,6 +127,18 @@ type ReclaimedResourceConfig struct {
 	// +optional
 	MinReclaimedResourceForAllocate *v1.ResourceList `json:"minReclaimedResourceForAllocate,omitempty"`
 
+	// NumaMinReclaimedResourceRatioForAllocate is a resource reserved ratio at numa level for reclaimed_cores pods，these resources will not be used
+	// by shared_cores pods.
+	// For example, {"cpu": 0.1, "memory": 0.2}.
+	// +optional
+	NumaMinReclaimedResourceRatioForAllocate *v1.ResourceList `json:"numaMinReclaimedResourceRatioForAllocate,omitempty"`
+
+	// NumaMinReclaimedResourceForAllocate is a resource reserved at numa level for reclaimed_cores pods，these resources will not be used
+	// by shared_cores pods.
+	// For example, {"cpu": 2, "memory": 0Gi}.
+	// +optional
+	NumaMinReclaimedResourceForAllocate *v1.ResourceList `json:"numaMinReclaimedResourceForAllocate,omitempty"`
+
 	// CPUHeadroomConfig is a configuration for cpu headroom
 	// +optional
 	CPUHeadroomConfig *CPUHeadroomConfig `json:"cpuHeadroomConfig,omitempty"`

--- a/pkg/apis/config/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/config/v1alpha1/zz_generated.deepcopy.go
@@ -2215,6 +2215,28 @@ func (in *ReclaimedResourceConfig) DeepCopyInto(out *ReclaimedResourceConfig) {
 			}
 		}
 	}
+	if in.NumaMinReclaimedResourceRatioForAllocate != nil {
+		in, out := &in.NumaMinReclaimedResourceRatioForAllocate, &out.NumaMinReclaimedResourceRatioForAllocate
+		*out = new(corev1.ResourceList)
+		if **in != nil {
+			in, out := *in, *out
+			*out = make(map[corev1.ResourceName]resource.Quantity, len(*in))
+			for key, val := range *in {
+				(*out)[key] = val.DeepCopy()
+			}
+		}
+	}
+	if in.NumaMinReclaimedResourceForAllocate != nil {
+		in, out := &in.NumaMinReclaimedResourceForAllocate, &out.NumaMinReclaimedResourceForAllocate
+		*out = new(corev1.ResourceList)
+		if **in != nil {
+			in, out := *in, *out
+			*out = make(map[corev1.ResourceName]resource.Quantity, len(*in))
+			for key, val := range *in {
+				(*out)[key] = val.DeepCopy()
+			}
+		}
+	}
 	if in.CPUHeadroomConfig != nil {
 		in, out := &in.CPUHeadroomConfig, &out.CPUHeadroomConfig
 		*out = new(CPUHeadroomConfig)


### PR DESCRIPTION
#### What type of PR is this?
Features

#### What this PR does / why we need it:
Previously, offline reserved resources configured fixedly at the node level may lead to excessive or insufficient reserved resources at the NUMA level. Therefore, configuring reserved resources at the NUMA dimension is supported, and proportional configuration based on NUMA size is adopted instead of fixed values.

