### PR TITLE
add CpuUsageRatioThreshold field for NUMA CPU pressure eviction config

### DIFF
--- a/config/crd/bases/config.katalyst.kubewharf.io_adminqosconfigurations.yaml
+++ b/config/crd/bases/config.katalyst.kubewharf.io_adminqosconfigurations.yaml
@@ -248,6 +248,11 @@ spec:
                                   when selecting pods to be evicted.
                                 minimum: 0
                                 type: integer
+                              cpuUsageRatioThreshold:
+                                description: CpuUsageRatioThreshold is the CPU usage
+                                  ratio threshold for NUMA-level CPU pressure eviction.
+                                minimum: 0
+                                type: number
                               enableEviction:
                                 description: EnableEviction indicates whether to enable
                                   NUMA-level CPU pressure eviction.

--- a/pkg/apis/config/v1alpha1/adminqos.go
+++ b/pkg/apis/config/v1alpha1/adminqos.go
@@ -540,6 +540,11 @@ type NumaCPUPressureEvictionConfig struct {
 	// +optional
 	ThresholdExpandFactor *float64 `json:"thresholdExpandFactor,omitempty"`
 
+	// CpuUsageRatioThreshold is the CPU usage ratio threshold for NUMA-level CPU pressure eviction.
+	// +kubebuilder:validation:Minimum=0
+	// +optional
+	CpuUsageRatioThreshold *float64 `json:"cpuUsageRatioThreshold,omitempty"`
+
 	// CandidateCount is the candidate pod count when selecting pods to be evicted.
 	// +kubebuilder:validation:Minimum=0
 	// +optional

--- a/pkg/apis/config/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/config/v1alpha1/zz_generated.deepcopy.go
@@ -2177,6 +2177,11 @@ func (in *NumaCPUPressureEvictionConfig) DeepCopyInto(out *NumaCPUPressureEvicti
 		*out = new(float64)
 		**out = **in
 	}
+	if in.CpuUsageRatioThreshold != nil {
+		in, out := &in.CpuUsageRatioThreshold, &out.CpuUsageRatioThreshold
+		*out = new(float64)
+		**out = **in
+	}
 	if in.CandidateCount != nil {
 		in, out := &in.CandidateCount, &out.CandidateCount
 		*out = new(int)


### PR DESCRIPTION
feat: add new qos region type

Signed-off-by: linzhecheng <linzhecheng@bytedance.com>

feat(consts): add gpu selection result annotation key

Add new constant for pod annotation key to store GPU selection results

feat(spd): add custom compare key annotation for SPD baseline

Add SPDAnnotationKeyCustomCompareKey so the SPD baseline sentinel can be selected against a workload-defined custom compare key (e.g. shard_id) instead of only timestamp/podName.

node: replace ResourceMetric with v1.ResourceList

consts: add ResourcePower for heterogeneous resource

feat(crd): support cpu system exclusive pool

feat: add config for cpu weight

Fix proto generation include paths

#### What type of PR is this?
<!--
Features/Bug fixes/Enhancements
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:
