### PR TITLE
feat(aqc): add EnableBypassCPUSetAdjustment flag for CPU plugin

### DIFF
--- a/config/crd/bases/config.katalyst.kubewharf.io_adminqosconfigurations.yaml
+++ b/config/crd/bases/config.katalyst.kubewharf.io_adminqosconfigurations.yaml
@@ -811,13 +811,17 @@ spec:
                       cpuPluginConfig:
                         description: CPUPluginConfig is the config for cpu plugin
                         properties:
+                          disableSharedCoresRampUp:
+                            description: |-
+                              DisableSharedCoresRampUp disables initial full-pool cpuset binding for
+                              newly scheduled shared_cores pods. When true, shared_cores pods are allocated
+                              from their target pool directly instead of entering RampUp.
+                            type: boolean
                           enableBypassCPUSetAdjustment:
                             description: |-
-                              EnableBypassCPUSetAdjustment is a flag to bypass cpuset backfill in QRM
-                              CPU plugin's PackAllocationResponse for shared_cores, reclaimed_cores and
-                              system_cores pools. When enabled, QRM will not populate cpuset for those
-                              pools during allocation, and cpuset adjustment is delegated to the
-                              reconcile plugin. Dedicated pools are unaffected.
+                              EnableBypassCPUSetAdjustment controls whether GetResourcesAllocation clears
+                              CPU AllocationResult for all QoS classes. Allocation responses returned by
+                              Allocate/AllocateForPod keep their cpuset unchanged.
                             type: boolean
                           preferUseExistNUMAHintResult:
                             description: |-

--- a/config/crd/bases/config.katalyst.kubewharf.io_adminqosconfigurations.yaml
+++ b/config/crd/bases/config.katalyst.kubewharf.io_adminqosconfigurations.yaml
@@ -811,6 +811,14 @@ spec:
                       cpuPluginConfig:
                         description: CPUPluginConfig is the config for cpu plugin
                         properties:
+                          enableBypassCPUSetAdjustment:
+                            description: |-
+                              EnableBypassCPUSetAdjustment is a flag to bypass cpuset backfill in QRM
+                              CPU plugin's PackAllocationResponse for shared_cores, reclaimed_cores and
+                              system_cores pools. When enabled, QRM will not populate cpuset for those
+                              pools during allocation, and cpuset adjustment is delegated to the
+                              reconcile plugin. Dedicated pools are unaffected.
+                            type: boolean
                           preferUseExistNUMAHintResult:
                             description: |-
                               PreferUseExistNUMAHintResult prefer to use existing numa hint results

--- a/pkg/apis/config/v1alpha1/adminqos.go
+++ b/pkg/apis/config/v1alpha1/adminqos.go
@@ -384,6 +384,13 @@ type CPUPluginConfig struct {
 	// The calculation results may originate from upstream components and be recorded in the pod annotation
 	// +optional
 	PreferUseExistNUMAHintResult *bool `json:"preferUseExistNUMAHintResult,omitempty"`
+	// EnableBypassCPUSetAdjustment is a flag to bypass cpuset backfill in QRM
+	// CPU plugin's PackAllocationResponse for shared_cores, reclaimed_cores and
+	// system_cores pools. When enabled, QRM will not populate cpuset for those
+	// pools during allocation, and cpuset adjustment is delegated to the
+	// reconcile plugin. Dedicated pools are unaffected.
+	// +optional
+	EnableBypassCPUSetAdjustment *bool `json:"enableBypassCPUSetAdjustment,omitempty"`
 	// SystemExclusivePool is the config for system exclusive pool, key is pool name, value is the number of cores to allocate
 	// +optional
 	SystemExclusivePool map[string]int `json:"systemExclusivePool,omitempty"`

--- a/pkg/apis/config/v1alpha1/adminqos.go
+++ b/pkg/apis/config/v1alpha1/adminqos.go
@@ -384,13 +384,16 @@ type CPUPluginConfig struct {
 	// The calculation results may originate from upstream components and be recorded in the pod annotation
 	// +optional
 	PreferUseExistNUMAHintResult *bool `json:"preferUseExistNUMAHintResult,omitempty"`
-	// EnableBypassCPUSetAdjustment is a flag to bypass cpuset backfill in QRM
-	// CPU plugin's PackAllocationResponse for shared_cores, reclaimed_cores and
-	// system_cores pools. When enabled, QRM will not populate cpuset for those
-	// pools during allocation, and cpuset adjustment is delegated to the
-	// reconcile plugin. Dedicated pools are unaffected.
+	// EnableBypassCPUSetAdjustment controls whether GetResourcesAllocation clears
+	// CPU AllocationResult for all QoS classes. Allocation responses returned by
+	// Allocate/AllocateForPod keep their cpuset unchanged.
 	// +optional
 	EnableBypassCPUSetAdjustment *bool `json:"enableBypassCPUSetAdjustment,omitempty"`
+	// DisableSharedCoresRampUp disables initial full-pool cpuset binding for
+	// newly scheduled shared_cores pods. When true, shared_cores pods are allocated
+	// from their target pool directly instead of entering RampUp.
+	// +optional
+	DisableSharedCoresRampUp *bool `json:"disableSharedCoresRampUp,omitempty"`
 	// SystemExclusivePool is the config for system exclusive pool, key is pool name, value is the number of cores to allocate
 	// +optional
 	SystemExclusivePool map[string]int `json:"systemExclusivePool,omitempty"`

--- a/pkg/apis/config/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/config/v1alpha1/zz_generated.deepcopy.go
@@ -537,6 +537,11 @@ func (in *CPUPluginConfig) DeepCopyInto(out *CPUPluginConfig) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.DisableSharedCoresRampUp != nil {
+		in, out := &in.DisableSharedCoresRampUp, &out.DisableSharedCoresRampUp
+		*out = new(bool)
+		**out = **in
+	}
 	if in.SystemExclusivePool != nil {
 		in, out := &in.SystemExclusivePool, &out.SystemExclusivePool
 		*out = make(map[string]int, len(*in))

--- a/pkg/apis/config/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/config/v1alpha1/zz_generated.deepcopy.go
@@ -532,6 +532,11 @@ func (in *CPUPluginConfig) DeepCopyInto(out *CPUPluginConfig) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.EnableBypassCPUSetAdjustment != nil {
+		in, out := &in.EnableBypassCPUSetAdjustment, &out.EnableBypassCPUSetAdjustment
+		*out = new(bool)
+		**out = **in
+	}
 	if in.SystemExclusivePool != nil {
 		in, out := &in.SystemExclusivePool, &out.SystemExclusivePool
 		*out = make(map[string]int, len(*in))


### PR DESCRIPTION
### What type of PR is this?

/kind feature

### What this PR does / why we need it

Add a new boolean field `EnableBypassCPUSetAdjustment` to `CPUPluginConfig` in `AdminQoSConfiguration` to allow bypassing cpuset backfill in QRM CPU plugin's `PackAllocationResponse` for `shared_cores`, `reclaimed_cores` and `system_cores` pools.

When enabled, QRM will not populate cpuset for those pools during allocation, and cpuset adjustment is delegated to the reconcile plugin instead. Dedicated pools are unaffected by this flag.

This enables a cleaner separation between allocation-time decisions (kept in QRM) and runtime cpuset reconciliation (moved to the reconcile plugin), which is required by the follow-up work in katalyst-core.

### Changes

- Add `EnableBypassCPUSetAdjustment *bool` field to `CPUPluginConfig` (`pkg/apis/config/v1alpha1/adminqos.go`).
- Regenerate `zz_generated.deepcopy.go` for the new pointer field.
- Update CRD schema `config/crd/bases/config.katalyst.kubewharf.io_adminqosconfigurations.yaml` accordingly.

### Which issue(s) this PR fixes

None.

### Special notes for your reviewer

- The field is `+optional` and defaults to unset (equivalent to `false`), so existing behavior is preserved.
- The corresponding consumer logic will land in a follow-up katalyst-core PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new optional configuration flag to bypass CPU-set adjustment for QoS-wide resource allocation behavior, with `GetResourcesAllocation` and pod allocation treated consistently when enabled.
* **Documentation**
  * Updated the configuration schema and descriptions to clarify the exact cpuset behavior difference between `GetResourcesAllocation` results and `Allocate/AllocateForPod` responses when the flag is turned on.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->