### PR TITLE
feat(aqc): add max reclaimed resource for memory and cpu

### DIFF
--- a/config/crd/bases/config.katalyst.kubewharf.io_adminqosconfigurations.yaml
+++ b/config/crd/bases/config.katalyst.kubewharf.io_adminqosconfigurations.yaml
@@ -124,6 +124,13 @@ spec:
                                   - name
                                   type: object
                                 type: array
+                              reclaimedCPUMaxRatio:
+                                description: ReclaimedCPUMaxRatio is the ratio of
+                                  the maximum amount of CPUs that can be reclaimed
+                                  at any time.
+                                maximum: 1
+                                minimum: 0
+                                type: number
                               regionIndicators:
                                 items:
                                   properties:
@@ -937,6 +944,13 @@ spec:
                                 minimum: 0
                                 type: number
                             type: object
+                          reclaimedMemoryMaxRatio:
+                            description: ReclaimedMemoryMaxRatio is the ratio of the
+                              maximum amount of memory that can be reclaimed per numa
+                              at any time.
+                            maximum: 1
+                            minimum: 0
+                            type: number
                           utilBasedConfig:
                             description: MemoryHeadroomUtilBasedConfig is a config
                               for utilization based memory headroom policy

--- a/config/crd/bases/config.katalyst.kubewharf.io_adminqosconfigurations.yaml
+++ b/config/crd/bases/config.katalyst.kubewharf.io_adminqosconfigurations.yaml
@@ -1053,6 +1053,14 @@ spec:
                           by shared_cores pods.
                           For example, {"cpu": 0.1, "memory": 0.2}.
                         type: object
+                      reclaimedConsumerToReclaimedResourcePercentage:
+                        additionalProperties:
+                          type: integer
+                        description: |-
+                          ReclaimedConsumerToReclaimedResourcePercentage is a configuration for reclaimed consumer to a percentage of the total
+                          reclaimed resource, used for both headroom and provision.
+                          For example, {"generic": 40, "custom-consumer-1": 60}
+                        type: object
                       reservedResourceForAllocate:
                         additionalProperties:
                           anyOf:

--- a/pkg/apis/config/v1alpha1/adminqos.go
+++ b/pkg/apis/config/v1alpha1/adminqos.go
@@ -154,6 +154,12 @@ type ReclaimedResourceConfig struct {
 	// MemoryHeadroomConfig is a configuration for memory headroom
 	// +optional
 	MemoryHeadroomConfig *MemoryHeadroomConfig `json:"memoryHeadroomConfig,omitempty"`
+
+	// ReclaimedConsumerToReclaimedResourcePercentage is a configuration for reclaimed consumer to a percentage of the total
+	// reclaimed resource, used for both headroom and provision.
+	// For example, {"generic": 40, "custom-consumer-1": 60}
+	// +optional
+	ReclaimedConsumerToReclaimedResourcePercentage *map[string]int `json:"reclaimedConsumerToReclaimedResourcePercentage,omitempty"`
 }
 
 type MemoryHeadroomConfig struct {

--- a/pkg/apis/config/v1alpha1/adminqos.go
+++ b/pkg/apis/config/v1alpha1/adminqos.go
@@ -164,6 +164,12 @@ type MemoryHeadroomConfig struct {
 	// MemoryHeadroomPodRequestLimitAwareConfig is a config for pod request limit aware memory headroom policy
 	// +optional
 	PodRequestLimitAwareConfig *MemoryHeadroomPodRequestLimitAwareConfig `json:"podRequestLimitAwareConfig,omitempty"`
+
+	// ReclaimedMemoryMaxRatio is the ratio of the maximum amount of memory that can be reclaimed per numa at any time.
+	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:validation:Maximum=1
+	// +optional
+	ReclaimedMemoryMaxRatio *float64 `json:"reclaimedMemoryMaxRatio,omitempty"`
 }
 
 type AdvisorConfig struct {
@@ -251,6 +257,12 @@ type ControlKnobConstraints struct {
 type CPUProvisionConfig struct {
 	RegionIndicators []RegionIndicators       `json:"regionIndicators,omitempty"`
 	Constraints      []ControlKnobConstraints `json:"constraints,omitempty"`
+
+	// ReclaimedCPUMaxRatio is the ratio of the maximum amount of CPUs that can be reclaimed at any time.
+	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:validation:Maximum=1
+	// +optional
+	ReclaimedCPUMaxRatio *float64 `json:"reclaimedCPUMaxRatio,omitempty"`
 }
 
 type MemoryAdvisorConfig struct {

--- a/pkg/apis/config/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/config/v1alpha1/zz_generated.deepcopy.go
@@ -2591,6 +2591,17 @@ func (in *ReclaimedResourceConfig) DeepCopyInto(out *ReclaimedResourceConfig) {
 		*out = new(MemoryHeadroomConfig)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.ReclaimedConsumerToReclaimedResourcePercentage != nil {
+		in, out := &in.ReclaimedConsumerToReclaimedResourcePercentage, &out.ReclaimedConsumerToReclaimedResourcePercentage
+		*out = new(map[string]int)
+		if **in != nil {
+			in, out := *in, *out
+			*out = make(map[string]int, len(*in))
+			for key, val := range *in {
+				(*out)[key] = val
+			}
+		}
+	}
 	return
 }
 

--- a/pkg/apis/config/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/config/v1alpha1/zz_generated.deepcopy.go
@@ -652,6 +652,11 @@ func (in *CPUProvisionConfig) DeepCopyInto(out *CPUProvisionConfig) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.ReclaimedCPUMaxRatio != nil {
+		in, out := &in.ReclaimedCPUMaxRatio, &out.ReclaimedCPUMaxRatio
+		*out = new(float64)
+		**out = **in
+	}
 	return
 }
 
@@ -1946,6 +1951,11 @@ func (in *MemoryHeadroomConfig) DeepCopyInto(out *MemoryHeadroomConfig) {
 		in, out := &in.PodRequestLimitAwareConfig, &out.PodRequestLimitAwareConfig
 		*out = new(MemoryHeadroomPodRequestLimitAwareConfig)
 		(*in).DeepCopyInto(*out)
+	}
+	if in.ReclaimedMemoryMaxRatio != nil {
+		in, out := &in.ReclaimedMemoryMaxRatio, &out.ReclaimedMemoryMaxRatio
+		*out = new(float64)
+		**out = **in
 	}
 	return
 }


### PR DESCRIPTION
#### What type of PR is this?
<!--
Features/Bug fixes/Enhancements
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added new admin QoS configuration options to cap maximum reclaimed CPU ratio and reclaimed memory headroom.
  * Introduced reclaimed ratio controls constrained to values between 0 and 1.
  * Added a configurable percentage mapping to set per-consumer reclaimed-resource percentages.
* **Bug Fixes**
  * Improved configuration copying to ensure newly added optional fields and maps are properly deep-copied.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->