### PR TITLE
feat(config): add tmo max reclaim size

### DIFF
--- a/config/crd/bases/config.katalyst.kubewharf.io_transparentmemoryoffloadingconfigurations.yaml
+++ b/config/crd/bases/config.katalyst.kubewharf.io_transparentmemoryoffloadingconfigurations.yaml
@@ -110,6 +110,15 @@ spec:
                               description: Interval is the minimum duration the objectives
                                 got memory reclaimed by TMO
                               type: string
+                            maxReclaimSize:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: MaxReclaimSize is a Kubernetes resource
+                                quantity that limits the size that can be reclaimed
+                                in one TMO cycle. Zero means unlimited.
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
                             policyName:
                               description: PolicyName is used to specify the policy
                                 for calculating memory offloading size
@@ -248,6 +257,15 @@ spec:
                               description: Interval is the minimum duration the objectives
                                 got memory reclaimed by TMO
                               type: string
+                            maxReclaimSize:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: MaxReclaimSize is a Kubernetes resource
+                                quantity that limits the size that can be reclaimed
+                                in one TMO cycle. Zero means unlimited.
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
                             policyName:
                               description: PolicyName is used to specify the policy
                                 for calculating memory offloading size
@@ -323,6 +341,15 @@ spec:
                               description: Interval is the minimum duration the objectives
                                 got memory reclaimed by TMO
                               type: string
+                            maxReclaimSize:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: MaxReclaimSize is a Kubernetes resource
+                                quantity that limits the size that can be reclaimed
+                                in one TMO cycle. Zero means unlimited.
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
                             policyName:
                               description: PolicyName is used to specify the policy
                                 for calculating memory offloading size

--- a/pkg/apis/config/v1alpha1/tmo.go
+++ b/pkg/apis/config/v1alpha1/tmo.go
@@ -17,8 +17,10 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"github.com/kubewharf/katalyst-api/pkg/consts"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kubewharf/katalyst-api/pkg/consts"
 )
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
@@ -134,6 +136,10 @@ type TMOConfigDetail struct {
 	// PolicyName is used to specify the policy for calculating memory offloading size
 	// +optional
 	PolicyName *TMOPolicyName `json:"policyName,omitempty"`
+
+	// MaxReclaimSize is a Kubernetes resource quantity that limits the size that can be reclaimed in one TMO cycle. Zero means unlimited.
+	// +optional
+	MaxReclaimSize *resource.Quantity `json:"maxReclaimSize,omitempty"`
 
 	// PSIPolicyConf is configurations of a TMO policy which reclaim memory by PSI
 	// +optional

--- a/pkg/apis/config/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/config/v1alpha1/zz_generated.deepcopy.go
@@ -3223,6 +3223,11 @@ func (in *TMOConfigDetail) DeepCopyInto(out *TMOConfigDetail) {
 		*out = new(TMOPolicyName)
 		**out = **in
 	}
+	if in.MaxReclaimSize != nil {
+		in, out := &in.MaxReclaimSize, &out.MaxReclaimSize
+		x := (*in).DeepCopy()
+		*out = &x
+	}
 	if in.PSIPolicyConf != nil {
 		in, out := &in.PSIPolicyConf, &out.PSIPolicyConf
 		*out = new(PSIPolicyConf)


### PR DESCRIPTION
#### What type of PR is this?
<!--
Features/Bug fixes/Enhancements
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional `maxReclaimSize` setting to control the maximum number of bytes that can be reclaimed in a single TMO cycle.
  * A value of `0` now means “unlimited”.
  * The setting is available for all supported configuration selector scopes (including Cgroup, pool name, and QoS level configurations).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->