### PR TITLE
Feat(numa cpu pressure eviction config)  add upper and lower bound

### DIFF
--- a/config/crd/bases/config.katalyst.kubewharf.io_adminqosconfigurations.yaml
+++ b/config/crd/bases/config.katalyst.kubewharf.io_adminqosconfigurations.yaml
@@ -264,6 +264,14 @@ spec:
                                 format: int64
                                 minimum: 0
                                 type: integer
+                              lowerBoundRatio:
+                                description: |-
+                                  LowerBoundRatio is the soft threshold ratio (0~1) applied to the NUMA CPU
+                                  usage ratio. When enough recent samples cross this bound but the upper bound
+                                  is not yet reached, the plugin reports SOFT_MET together with a NodeCondition
+                                maximum: 1
+                                minimum: 0
+                                type: number
                               metricRingSize:
                                 description: MetricRingSize is the size of the metric
                                   ring buffer for calculating NUMA CPU pressure.
@@ -285,6 +293,15 @@ spec:
                                 description: |-
                                   ThresholdMetPercentage is the percentage of time the NUMA's CPU pressure
                                   must be above the threshold for an eviction to be triggered.
+                                maximum: 1
+                                minimum: 0
+                                type: number
+                              upperBoundRatio:
+                                description: |-
+                                  UpperBoundRatio is the hard threshold ratio (0~1) applied to the NUMA CPU
+                                  usage ratio. When enough recent samples cross this bound, the plugin reports
+                                  HARD_MET together with a NodeCondition + NoSchedule taint, which allows the
+                                  eviction manager to actually evict candidate pods.
                                 maximum: 1
                                 minimum: 0
                                 type: number

--- a/pkg/apis/config/v1alpha1/adminqos.go
+++ b/pkg/apis/config/v1alpha1/adminqos.go
@@ -554,18 +554,15 @@ type NumaCPUPressureEvictionConfig struct {
 	// +kubebuilder:validation:Minimum=0
 	// +optional
 	GracePeriod *int64 `json:"gracePeriod,omitempty"`
-
 	// ThresholdExpandFactor expands the metric threshold from a specific machine to set the eviction threshold.
 	// E.g., 1.1 means a 10% increase.
 	// +kubebuilder:validation:Minimum=0
 	// +optional
 	ThresholdExpandFactor *float64 `json:"thresholdExpandFactor,omitempty"`
-
 	// CpuUsageRatioThreshold is the CPU usage ratio threshold for NUMA-level CPU pressure eviction.
 	// +kubebuilder:validation:Minimum=0
 	// +optional
 	CpuUsageRatioThreshold *float64 `json:"cpuUsageRatioThreshold,omitempty"`
-
 	// CandidateCount is the candidate pod count when selecting pods to be evicted.
 	// +kubebuilder:validation:Minimum=0
 	// +optional
@@ -574,6 +571,24 @@ type NumaCPUPressureEvictionConfig struct {
 	// SkippedPodKinds is the pod kind that will be skipped when selecting pods to be evicted.
 	// +optional
 	SkippedPodKinds []string `json:"skippedPodKinds,omitempty"`
+
+	// UpperBoundRatio is the hard threshold ratio (0~1) applied to the NUMA CPU
+	// usage ratio. When enough recent samples cross this bound, the plugin reports
+	// HARD_MET together with a NodeCondition + NoSchedule taint, which allows the
+	// eviction manager to actually evict candidate pods.
+	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:validation:Maximum=1
+	// +optional
+	UpperBoundRatio *float64 `json:"upperBoundRatio,omitempty"`
+
+	// LowerBoundRatio is the soft threshold ratio (0~1) applied to the NUMA CPU
+	// usage ratio. When enough recent samples cross this bound but the upper bound
+	// is not yet reached, the plugin reports SOFT_MET together with a NodeCondition
+	// + NoSchedule taint, which only prevents new scheduling without evicting pods.
+	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:validation:Maximum=1
+	// +optional
+	LowerBoundRatio *float64 `json:"lowerBoundRatio,omitempty"`
 }
 
 // NumaSysCPUPressureEvictionConfig holds the configurations for NUMA-level system CPU pressure eviction.

--- a/pkg/apis/config/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/config/v1alpha1/zz_generated.deepcopy.go
@@ -2218,6 +2218,16 @@ func (in *NumaCPUPressureEvictionConfig) DeepCopyInto(out *NumaCPUPressureEvicti
 		*out = new(float64)
 		**out = **in
 	}
+	if in.UpperBoundRatio != nil {
+		in, out := &in.UpperBoundRatio, &out.UpperBoundRatio
+		*out = new(float64)
+		**out = **in
+	}
+	if in.LowerBoundRatio != nil {
+		in, out := &in.LowerBoundRatio, &out.LowerBoundRatio
+		*out = new(float64)
+		**out = **in
+	}
 	if in.CandidateCount != nil {
 		in, out := &in.CandidateCount, &out.CandidateCount
 		*out = new(int)


### PR DESCRIPTION
#### What type of PR is this?
<!--
Features
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
change for katalyst qrm plugin numa_cpu_pressure_eviction update
updated plugin will evict workload by bound instead of prior threshold
#### Special notes for your reviewer:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added two configurable NUMA CPU pressure eviction ratio thresholds: `lowerBoundRatio` (soft) and `upperBoundRatio` (hard).
  * Both thresholds are validated to be between **0** and **1**.
  * When the NUMA CPU usage ratio crosses these thresholds, behavior changes accordingly: soft threshold reports softer pressure handling, while the hard threshold enables eviction (including NoSchedule taint behavior) for candidate pods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->