### PR TITLE
feat(cpu): support container_cpu_idle_rate

### DIFF
--- a/pkg/consts/pod.go
+++ b/pkg/consts/pod.go
@@ -16,6 +16,19 @@ limitations under the License.
 
 package consts
 
+// ContainerCPUIdleRateConfig defines the annotation value schema for
+// PodAnnotationContainerCPUIdleRateKey.
+//
+// The key is the container name, and the value is the target CPU idle rate
+// percentage for that container in the inclusive range [0, 100].
+//
+// For example:
+//
+//	{
+//	  "testContainer": 50
+//	}
+type ContainerCPUIdleRateConfig map[string]int64
+
 // const variables for pod annotations about vpa in-place resource update.
 const (
 	PodAnnotationInplaceUpdateResourcesKey = "pod.kubernetes.io/resizeResources"
@@ -77,4 +90,17 @@ const (
 	PodAnnotationCPUWeightDemandCoresKey = "katalyst.kubewharf.io/cpu_weight_demand_cores"
 	// PodAnnotationCPUWeightBurstRatioKey is a const variable for pod annotation about cpu burst ratio to calculate cpu weight.
 	PodAnnotationCPUWeightBurstRatioKey = "katalyst.kubewharf.io/cpu_weight_burst_ratio"
+)
+
+const (
+	// PodAnnotationContainerCPUIdleRateKey is a const variable for pod annotation about per-container cpu idle rate.
+	//
+	// The annotation value is expected to be a JSON object encoded from ContainerCPUIdleRateConfig.
+	// Each per-container value is a percentage in the inclusive range [0, 100].
+	//
+	// For example:
+	// {
+	//   "testContainer": 50
+	// }
+	PodAnnotationContainerCPUIdleRateKey = "katalyst.kubewharf.io/container_cpu_idle_rate"
 )


### PR DESCRIPTION
#### What type of PR is this?
Features:  support container_cpu_idle_rate

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### English

- Added the public `ContainerCPUIdleRateConfig` type and `PodAnnotationContainerCPUIdleRateKey` constant in `pkg/consts/pod.go`.
- Documented the JSON mapping from container names to target CPU idle-rate percentages.
- This is an additive API change and does not break existing consumers.
- No generated code changes are required.
- Downstream consumers can parse the annotation when they support `container_cpu_idle_rate`.

### 简体中文

- 在 `pkg/consts/pod.go` 中新增公共类型 `ContainerCPUIdleRateConfig` 和常量 `PodAnnotationContainerCPUIdleRateKey`。
- 已记录容器名称到目标 CPU idle-rate 百分比的 JSON 映射格式。
- 这是兼容的增量 API 变更，不会破坏现有消费者。
- 不需要修改生成代码。
- 下游消费者支持 `container_cpu_idle_rate` 后，可以解析该 annotation。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->