### PR TITLE
feat: add global TCP memory pressure eviction AQC fields

### DIFF
--- a/config/crd/bases/config.katalyst.kubewharf.io_adminqosconfigurations.yaml
+++ b/config/crd/bases/config.katalyst.kubewharf.io_adminqosconfigurations.yaml
@@ -454,6 +454,10 @@ spec:
                         description: MemoryPressureEvictionConfig is the config for
                           memory pressure eviction
                         properties:
+                          enableGlobalTCPMemoryPressureEviction:
+                            description: EnableGlobalTCPMemoryPressureEviction is
+                              whether to enable global TCP memory pressure eviction.
+                            type: boolean
                           enableNumaLevelEviction:
                             description: EnableNumaLevelEviction is whether to enable
                               numa-level eviction
@@ -474,6 +478,27 @@ spec:
                             description: EvictNonReclaimedLabelSelector is a non-reclaimed
                               pod eviction label selector
                             type: string
+                          globalTCPMemoryCoolDownPeriodSeconds:
+                            description: |-
+                              GlobalTCPMemoryCoolDownPeriodSeconds is the cool-down period in seconds between global TCP memory eviction
+                              candidate selections.
+                            format: int64
+                            minimum: 0
+                            type: integer
+                          globalTCPMemoryHardThresholdRatio:
+                            description: GlobalTCPMemoryHardThresholdRatio is the
+                              hard threshold ratio of global TCP memory utilization.
+                            exclusiveMinimum: true
+                            maximum: 1
+                            minimum: 0
+                            type: number
+                          globalTCPMemoryThresholdMetToleranceDuration:
+                            description: |-
+                              GlobalTCPMemoryThresholdMetToleranceDuration is the duration in seconds that global TCP memory utilization
+                              must continuously exceed the hard threshold before eviction is triggered.
+                            format: int64
+                            minimum: 0
+                            type: integer
                           gracePeriod:
                             description: GracePeriod is the grace period of memory
                               pressure eviction

--- a/config/crd/bases/config.katalyst.kubewharf.io_adminqosconfigurations.yaml
+++ b/config/crd/bases/config.katalyst.kubewharf.io_adminqosconfigurations.yaml
@@ -478,13 +478,11 @@ spec:
                             description: EvictNonReclaimedLabelSelector is a non-reclaimed
                               pod eviction label selector
                             type: string
-                          globalTCPMemoryCoolDownPeriodSeconds:
+                          globalTCPMemoryCoolDownPeriod:
                             description: |-
-                              GlobalTCPMemoryCoolDownPeriodSeconds is the cool-down period in seconds between global TCP memory eviction
+                              GlobalTCPMemoryCoolDownPeriod is the cool-down period between global TCP memory eviction
                               candidate selections.
-                            format: int64
-                            minimum: 0
-                            type: integer
+                            type: string
                           globalTCPMemoryHardThresholdRatio:
                             description: GlobalTCPMemoryHardThresholdRatio is the
                               hard threshold ratio of global TCP memory utilization.
@@ -494,11 +492,9 @@ spec:
                             type: number
                           globalTCPMemoryThresholdMetToleranceDuration:
                             description: |-
-                              GlobalTCPMemoryThresholdMetToleranceDuration is the duration in seconds that global TCP memory utilization
+                              GlobalTCPMemoryThresholdMetToleranceDuration is the duration that global TCP memory utilization
                               must continuously exceed the hard threshold before eviction is triggered.
-                            format: int64
-                            minimum: 0
-                            type: integer
+                            type: string
                           gracePeriod:
                             description: GracePeriod is the grace period of memory
                               pressure eviction

--- a/pkg/apis/config/v1alpha1/adminqos.go
+++ b/pkg/apis/config/v1alpha1/adminqos.go
@@ -734,17 +734,15 @@ type MemoryPressureEvictionConfig struct {
 	// +optional
 	GlobalTCPMemoryHardThresholdRatio *float64 `json:"globalTCPMemoryHardThresholdRatio,omitempty"`
 
-	// GlobalTCPMemoryThresholdMetToleranceDuration is the duration in seconds that global TCP memory utilization
+	// GlobalTCPMemoryThresholdMetToleranceDuration is the duration that global TCP memory utilization
 	// must continuously exceed the hard threshold before eviction is triggered.
-	// +kubebuilder:validation:Minimum=0
 	// +optional
-	GlobalTCPMemoryThresholdMetToleranceDuration *int64 `json:"globalTCPMemoryThresholdMetToleranceDuration,omitempty"`
+	GlobalTCPMemoryThresholdMetToleranceDuration *metav1.Duration `json:"globalTCPMemoryThresholdMetToleranceDuration,omitempty"`
 
-	// GlobalTCPMemoryCoolDownPeriodSeconds is the cool-down period in seconds between global TCP memory eviction
+	// GlobalTCPMemoryCoolDownPeriod is the cool-down period between global TCP memory eviction
 	// candidate selections.
-	// +kubebuilder:validation:Minimum=0
 	// +optional
-	GlobalTCPMemoryCoolDownPeriodSeconds *int64 `json:"globalTCPMemoryCoolDownPeriodSeconds,omitempty"`
+	GlobalTCPMemoryCoolDownPeriod *metav1.Duration `json:"globalTCPMemoryCoolDownPeriod,omitempty"`
 }
 
 type SystemLoadPressureEvictionConfig struct {

--- a/pkg/apis/config/v1alpha1/adminqos.go
+++ b/pkg/apis/config/v1alpha1/adminqos.go
@@ -722,6 +722,29 @@ type MemoryPressureEvictionConfig struct {
 	// EvictNonReclaimedLabelSelector is a non-reclaimed pod eviction label selector
 	// +optional
 	EvictNonReclaimedLabelSelector string `json:"evictNonReclaimedLabelSelector,omitempty"`
+
+	// EnableGlobalTCPMemoryPressureEviction is whether to enable global TCP memory pressure eviction.
+	// +optional
+	EnableGlobalTCPMemoryPressureEviction *bool `json:"enableGlobalTCPMemoryPressureEviction,omitempty"`
+
+	// GlobalTCPMemoryHardThresholdRatio is the hard threshold ratio of global TCP memory utilization.
+	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:validation:Maximum=1
+	// +kubebuilder:validation:ExclusiveMinimum=true
+	// +optional
+	GlobalTCPMemoryHardThresholdRatio *float64 `json:"globalTCPMemoryHardThresholdRatio,omitempty"`
+
+	// GlobalTCPMemoryThresholdMetToleranceDuration is the duration in seconds that global TCP memory utilization
+	// must continuously exceed the hard threshold before eviction is triggered.
+	// +kubebuilder:validation:Minimum=0
+	// +optional
+	GlobalTCPMemoryThresholdMetToleranceDuration *int64 `json:"globalTCPMemoryThresholdMetToleranceDuration,omitempty"`
+
+	// GlobalTCPMemoryCoolDownPeriodSeconds is the cool-down period in seconds between global TCP memory eviction
+	// candidate selections.
+	// +kubebuilder:validation:Minimum=0
+	// +optional
+	GlobalTCPMemoryCoolDownPeriodSeconds *int64 `json:"globalTCPMemoryCoolDownPeriodSeconds,omitempty"`
 }
 
 type SystemLoadPressureEvictionConfig struct {

--- a/pkg/apis/config/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/config/v1alpha1/zz_generated.deepcopy.go
@@ -2266,6 +2266,26 @@ func (in *MemoryPressureEvictionConfig) DeepCopyInto(out *MemoryPressureEviction
 		*out = new(int64)
 		**out = **in
 	}
+	if in.EnableGlobalTCPMemoryPressureEviction != nil {
+		in, out := &in.EnableGlobalTCPMemoryPressureEviction, &out.EnableGlobalTCPMemoryPressureEviction
+		*out = new(bool)
+		**out = **in
+	}
+	if in.GlobalTCPMemoryHardThresholdRatio != nil {
+		in, out := &in.GlobalTCPMemoryHardThresholdRatio, &out.GlobalTCPMemoryHardThresholdRatio
+		*out = new(float64)
+		**out = **in
+	}
+	if in.GlobalTCPMemoryThresholdMetToleranceDuration != nil {
+		in, out := &in.GlobalTCPMemoryThresholdMetToleranceDuration, &out.GlobalTCPMemoryThresholdMetToleranceDuration
+		*out = new(int64)
+		**out = **in
+	}
+	if in.GlobalTCPMemoryCoolDownPeriodSeconds != nil {
+		in, out := &in.GlobalTCPMemoryCoolDownPeriodSeconds, &out.GlobalTCPMemoryCoolDownPeriodSeconds
+		*out = new(int64)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/config/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/config/v1alpha1/zz_generated.deepcopy.go
@@ -2278,12 +2278,12 @@ func (in *MemoryPressureEvictionConfig) DeepCopyInto(out *MemoryPressureEviction
 	}
 	if in.GlobalTCPMemoryThresholdMetToleranceDuration != nil {
 		in, out := &in.GlobalTCPMemoryThresholdMetToleranceDuration, &out.GlobalTCPMemoryThresholdMetToleranceDuration
-		*out = new(int64)
+		*out = new(v1.Duration)
 		**out = **in
 	}
-	if in.GlobalTCPMemoryCoolDownPeriodSeconds != nil {
-		in, out := &in.GlobalTCPMemoryCoolDownPeriodSeconds, &out.GlobalTCPMemoryCoolDownPeriodSeconds
-		*out = new(int64)
+	if in.GlobalTCPMemoryCoolDownPeriod != nil {
+		in, out := &in.GlobalTCPMemoryCoolDownPeriod, &out.GlobalTCPMemoryCoolDownPeriod
+		*out = new(v1.Duration)
 		**out = **in
 	}
 	return


### PR DESCRIPTION
Add four new fields to MemoryPressureEvictionConfig:
- EnableGlobalTCPMemoryPressureEviction to control global TCP memory pressure eviction enablement
- GlobalTCPMemoryHardThresholdRatio to configure the TCP memory utilization hard threshold
- GlobalTCPMemoryThresholdMetToleranceDuration to configure how long the threshold must be continuously exceeded
- GlobalTCPMemoryCoolDownPeriodSeconds to configure the minimum interval between candidate selections

Also update CRD definitions and deepcopy logic for the new fields.

## What type of PR is this?

/kind feature

## What this PR does / why we need it:

### English

- Adds optional `EnableGlobalTCPMemoryPressureEviction` to `MemoryPressureEvictionConfig`.
- Adds optional `GlobalTCPMemoryHardThresholdRatio` with a valid range of `(0, 1]`.
- Adds optional `GlobalTCPMemoryThresholdMetToleranceDuration` and `GlobalTCPMemoryCoolDownPeriodSeconds`, both expressed in seconds and required to be non-negative.
- Updates the AQC CRD definition and generated deepcopy method for the new fields.
- Existing configurations remain compatible because all new fields are optional.
- Downstream consumers can use these fields to dynamically configure global TCP memory pressure eviction through AQC/KCC.
- Consumers should preserve runtime defaults when optional fields are omitted.
- This change only includes API, CRD, and generated-code updates. Runtime AQC/KCC integration is not included.

### 简体中文

- 为 `MemoryPressureEvictionConfig` 添加可选字段 `EnableGlobalTCPMemoryPressureEviction`。
- 添加可选字段 `GlobalTCPMemoryHardThresholdRatio`，有效范围为 `(0, 1]`。
- 添加可选字段 `GlobalTCPMemoryThresholdMetToleranceDuration` 和 `GlobalTCPMemoryCoolDownPeriodSeconds`，单位均为秒，且不得小于 `0`。
- 更新 AQC CRD definition 和生成的 deepcopy 方法，以支持新增字段。
- 由于所有新增字段均为可选字段，现有配置保持兼容。
- 下游消费者可以通过这些字段使用 AQC/KCC 动态配置全局 TCP 内存压力驱逐。
- 当可选字段未设置时，下游消费者应保留运行时默认值。
- 本次变更仅包含 API、CRD 和生成代码更新，不包含运行时 AQC/KCC 接入。

## Which issue(s) this PR fixes:

None.

## Special notes for your reviewer:

The four fields correspond to the existing runtime configuration defaults:

- `EnableGlobalTCPMemoryPressureEviction`: `false`
- `GlobalTCPMemoryHardThresholdRatio`: `0.8`
- `GlobalTCPMemoryThresholdMetToleranceDuration`: `60`
- `GlobalTCPMemoryCoolDownPeriodSeconds`: `60`

The defaults are intentionally not applied by the CRD schema. The fields use pointer types so downstream consumers can distinguish an omitted value from an explicitly configured zero or false value.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### English

- Adds four optional pointer fields to `MemoryPressureEvictionConfig` for global TCP memory pressure eviction.
- Changes tolerance and cooldown settings from integer seconds to `*metav1.Duration`.
- Renames `GlobalTCPMemoryCoolDownPeriodSeconds` to `GlobalTCPMemoryCoolDownPeriod`, which changes the API field and JSON key.
- Keeps the hard-threshold ratio constrained to `(0, 1]`. Tolerance and cooldown durations must be non-negative.
- Preserves omitted-field compatibility and runtime defaults. Pointer types preserve explicit `false` and zero values.
- Updates generated `DeepCopyInto` logic in `pkg/apis/config/v1alpha1/zz_generated.deepcopy.go`.
- Downstream consumers must use duration values and the new cooldown field name in AQC CRD configurations. Runtime AQC/KCC integration is not included.
- The deepcopy change is generated-only. The API declaration changes require corresponding CRD and consumer updates.

### 简体中文

- 为 `MemoryPressureEvictionConfig` 添加四个可选指针字段，用于配置全局 TCP memory pressure eviction。
- 将 tolerance 和 cooldown 设置从 integer seconds 改为 `*metav1.Duration`。
- 将 `GlobalTCPMemoryCoolDownPeriodSeconds` 重命名为 `GlobalTCPMemoryCoolDown`，同时修改 API 字段和 JSON key。
- 保留 hard-threshold ratio 的 `(0, 1]` 约束。Tolerance 和 cooldown duration 必须为非负值。
- 字段未设置时保持兼容性和现有 runtime defaults。指针类型保留显式 `false` 和零值。
- 更新 `pkg/apis/config/v1alpha1/zz_generated.deepcopy.go` 中生成的 `DeepCopyInto` 逻辑。
- 下游消费者必须在 AQC CRD 配置中使用 duration 值和新的 cooldown 字段名。本 PR 不包含 runtime AQC/KCC integration。
- `DeepCopyInto` 变更仅涉及生成代码。API 声明变更需要同步更新 CRD 和下游消费者。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->