### PR TITLE
feat: add validations for admin qos config fields

### DIFF
--- a/config/crd/bases/config.katalyst.kubewharf.io_adminqosconfigurations.yaml
+++ b/config/crd/bases/config.katalyst.kubewharf.io_adminqosconfigurations.yaml
@@ -912,6 +912,10 @@ spec:
 
 
                                   Default: "madvise".
+                                enum:
+                                - madvise
+                                - always
+                                - never
                                 type: string
                               thpHighOrderScoreThreshold:
                                 description: |-
@@ -940,18 +944,18 @@ spec:
                                   for kswapd asynchronous reclaim (e.g. 10GB on a 100GB NUMA -> 1000).
                                   It only takes effect when VMWatermarkScaleFactor is 0.
                                 format: int64
+                                minimum: 0
                                 type: integer
                               vmExtFragThreshold:
-                                description: |-
-                                  VMExtFragThreshold sets /proc/sys/vm/extfrag_threshold
-                                  0 means do not change.
+                                description: VMExtFragThreshold sets /proc/sys/vm/extfrag_threshold
                                 format: int64
+                                maximum: 1000
+                                minimum: 0
                                 type: integer
                               vmWatermarkBoostFactor:
-                                description: |-
-                                  VMWatermarkBoostFactor sets /proc/sys/vm/watermark_boost_factor
-                                  0 means do not change.
+                                description: VMWatermarkBoostFactor sets /proc/sys/vm/watermark_boost_factor
                                 format: int64
+                                minimum: 0
                                 type: integer
                               vmWatermarkScaleFactor:
                                 description: |-

--- a/pkg/apis/config/v1alpha1/adminqos.go
+++ b/pkg/apis/config/v1alpha1/adminqos.go
@@ -426,6 +426,7 @@ type FragMemConfig struct {
 	// fragmentation is not severe. Valid values: "madvise", "always", "never".
 	//
 	// Default: "madvise".
+	// +kubebuilder:validation:Enum=madvise;always;never
 	// +optional
 	THPDefaultConfig *string `json:"thpDefaultConfig,omitempty"`
 	// THPHighOrderScoreThreshold sets the threshold of highOrderScore for THP tuning.
@@ -447,15 +448,19 @@ type HostWatermarkConfig struct {
 	// +optional
 	VMWatermarkScaleFactor *int64 `json:"vmWatermarkScaleFactor,omitempty"`
 	// VMWatermarkBoostFactor sets /proc/sys/vm/watermark_boost_factor
+	// +kubebuilder:validation:Minimum=0
 	// +optional
 	VMWatermarkBoostFactor *int64 `json:"vmWatermarkBoostFactor,omitempty"`
 	// VMExtFragThreshold sets /proc/sys/vm/extfrag_threshold
+	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:validation:Maximum=1000
 	// +optional
 	VMExtFragThreshold *int64 `json:"vmExtFragThreshold,omitempty"`
 	// ReservedKswapdWatermarkGB is used to calculate watermark_scale_factor automatically.
 	// It means we want to reserve this amount of memory on a single NUMA node
 	// for kswapd asynchronous reclaim (e.g. 10GB on a 100GB NUMA -> 1000).
 	// It only takes effect when VMWatermarkScaleFactor is 0.
+	// +kubebuilder:validation:Minimum=0
 	// +optional
 	ReservedKswapdWatermarkGB *int64 `json:"reservedKswapdWatermarkGB,omitempty"`
 }


### PR DESCRIPTION
Add proper kubebuilder validation markers to AdminQoS API structs and update generated CRD manifests:
- Add enum validation for THPDefaultConfig to allow madvise, always, never
- Set minimum 0 for VMWatermarkBoostFactor, VMExtFragThreshold and ReservedKswapdWatermarkGB
- Set maximum 1000 for VMExtFragThreshold Clean up redundant description text in the CRD manifests during the update.

#### What type of PR is this?
<!--
Features/Bug fixes/Enhancements
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

### English

- Adds Kubernetes validation markers to `FragMemConfig` and `HostWatermarkConfig`.
- Restricts `THPDefaultConfig` to `madvise`, `always`, or `never`.
- Requires non-negative values for `VMWatermarkBoostFactor`, `VMExtFragThreshold`, and `ReservedKswapdWatermarkGB`.
- Restricts `VMExtFragThreshold` to `0–1000`.
- Updates generated CRD manifests and removes redundant description text.
- These changes tighten API validation and may reject previously accepted invalid values. Valid configurations remain compatible.
- Downstream consumers should update invalid manifests and rely on CRD validation. No exported API declarations changed.

### 简体中文

- 为 `FragMemConfig` 和 `HostWatermarkConfig` 添加 Kubernetes validation markers。
- 将 `THPDefaultConfig` 限制为 `madvise`、`always` 或 `never`。
- 要求 `VMWatermarkBoostFactor`、`VMExtFragThreshold` 和 `ReservedKswapdWatermarkGB` 使用非负值。
- 将 `VMExtFragThreshold` 限制为 `0–1000`。
- 更新生成的 CRD manifests，并移除冗余描述文本。
- 这些变更收紧 API validation。之前可接受的无效值可能被拒绝。有效配置保持兼容。
- 下游消费者应更新无效 manifests，并依赖 CRD validation。未更改 exported API declarations。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->