### PR TITLE
feat(tmo): add swappiness reclaim feature field

### DIFF
--- a/config/crd/bases/config.katalyst.kubewharf.io_transparentmemoryoffloadingconfigurations.yaml
+++ b/config/crd/bases/config.katalyst.kubewharf.io_transparentmemoryoffloadingconfigurations.yaml
@@ -102,6 +102,10 @@ spec:
                               description: EnableSwap is whether to enable swap to
                                 offloading anon pages
                               type: boolean
+                            enableSwappinessReclaim:
+                              description: EnableSwappinessReclaim is whether to set
+                                swappiness for individual TMO reclaim requests.
+                              type: boolean
                             enableTMO:
                               description: EnableTMO is whether to enable TMO on target
                                 objective
@@ -249,6 +253,10 @@ spec:
                               description: EnableSwap is whether to enable swap to
                                 offloading anon pages
                               type: boolean
+                            enableSwappinessReclaim:
+                              description: EnableSwappinessReclaim is whether to set
+                                swappiness for individual TMO reclaim requests.
+                              type: boolean
                             enableTMO:
                               description: EnableTMO is whether to enable TMO on target
                                 objective
@@ -332,6 +340,10 @@ spec:
                             enableSwap:
                               description: EnableSwap is whether to enable swap to
                                 offloading anon pages
+                              type: boolean
+                            enableSwappinessReclaim:
+                              description: EnableSwappinessReclaim is whether to set
+                                swappiness for individual TMO reclaim requests.
                               type: boolean
                             enableTMO:
                               description: EnableTMO is whether to enable TMO on target

--- a/pkg/apis/config/v1alpha1/tmo.go
+++ b/pkg/apis/config/v1alpha1/tmo.go
@@ -125,6 +125,10 @@ type TMOConfigDetail struct {
 	// +optional
 	EnableSwap *bool `json:"enableSwap,omitempty"`
 
+	// EnableSwappinessReclaim is whether to set swappiness for individual TMO reclaim requests.
+	// +optional
+	EnableSwappinessReclaim *bool `json:"enableSwappinessReclaim,omitempty"`
+
 	// ReservedInactiveFile is the reserved value of inactive file memory
 	// +optional
 	ReservedInactiveFile *uint64 `json:"reservedInactiveFile,omitempty"`

--- a/pkg/apis/config/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/config/v1alpha1/zz_generated.deepcopy.go
@@ -3374,6 +3374,11 @@ func (in *TMOConfigDetail) DeepCopyInto(out *TMOConfigDetail) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.EnableSwappinessReclaim != nil {
+		in, out := &in.EnableSwappinessReclaim, &out.EnableSwappinessReclaim
+		*out = new(bool)
+		**out = **in
+	}
 	if in.ReservedInactiveFile != nil {
 		in, out := &in.ReservedInactiveFile, &out.ReservedInactiveFile
 		*out = new(uint64)


### PR DESCRIPTION
#### What type of PR is this?
<!--
Features/Bug fixes/Enhancements
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

### English

- Added optional `EnableSwappinessReclaim *bool` to `TMOConfigDetail`.
- Updated generated deep-copy code to copy the field independently.
- This is backward-compatible. Existing configurations retain current behavior when the field is unset.
- Downstream consumers can set the field for individual TMO reclaim requests.
- No documentation or test changes are included.

### 简体中文

- 在 `TMOConfigDetail` 中新增可选字段 `EnableSwappinessReclaim *bool`。
- 更新生成的 deep-copy 代码，以独立复制该字段。
- 此变更保持向后兼容。未设置该字段时，现有配置保持当前行为。
- 下游消费者可以为单个 TMO reclaim request 设置该字段。
- 本次变更不包含文档或测试更新。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->