### PR TITLE
feat: add pod sale mode constants

### DIFF
--- a/config/crd/bases/config.katalyst.kubewharf.io_adminqosconfigurations.yaml
+++ b/config/crd/bases/config.katalyst.kubewharf.io_adminqosconfigurations.yaml
@@ -512,6 +512,7 @@ spec:
                               enum:
                               - qos.pod
                               - priority.pod
+                              - sale_mode.pod
                               - mem.total.numa.container
                               type: string
                             minItems: 1
@@ -561,6 +562,7 @@ spec:
                               enum:
                               - qos.pod
                               - priority.pod
+                              - sale_mode.pod
                               - mem.usage.container
                               - native.qos.pod
                               - owner.pod
@@ -948,15 +950,11 @@ spec:
                                 format: int64
                                 type: integer
                               vmExtFragThreshold:
-                                description: |-
-                                  VMExtFragThreshold sets /proc/sys/vm/extfrag_threshold
-                                  0 means do not change.
+                                description: VMExtFragThreshold sets /proc/sys/vm/extfrag_threshold
                                 format: int64
                                 type: integer
                               vmWatermarkBoostFactor:
-                                description: |-
-                                  VMWatermarkBoostFactor sets /proc/sys/vm/watermark_boost_factor
-                                  0 means do not change.
+                                description: VMWatermarkBoostFactor sets /proc/sys/vm/watermark_boost_factor
                                 format: int64
                                 type: integer
                               vmWatermarkScaleFactor:

--- a/pkg/apis/config/v1alpha1/adminqos.go
+++ b/pkg/apis/config/v1alpha1/adminqos.go
@@ -1010,12 +1010,12 @@ type CPUSystemPressureEvictionConfig struct {
 
 // NumaEvictionRankingMetric is the metrics used to rank pods for eviction at the
 // NUMA level
-// +kubebuilder:validation:Enum=qos.pod;priority.pod;mem.total.numa.container
+// +kubebuilder:validation:Enum=qos.pod;priority.pod;sale_mode.pod;mem.total.numa.container
 type NumaEvictionRankingMetric string
 
 // SystemEvictionRankingMetric is the metrics used to rank pods for eviction at the
 // system level
-// +kubebuilder:validation:Enum=qos.pod;priority.pod;mem.usage.container;native.qos.pod;owner.pod
+// +kubebuilder:validation:Enum=qos.pod;priority.pod;sale_mode.pod;mem.usage.container;native.qos.pod;owner.pod
 type SystemEvictionRankingMetric string
 
 // ReclaimResourceIndicators defines the workload configuration for reclaim resource indicators.

--- a/pkg/consts/pod.go
+++ b/pkg/consts/pod.go
@@ -65,6 +65,19 @@ const (
 	PodAnnotationResourcePoolKey = "katalyst.kubewharf.io/resource_pool"
 )
 
+// PodAnnotationSaleModeKey is a const variable for pod annotation about sale mode.
+const (
+	PodAnnotationSaleModeKey = "katalyst.kubewharf.io/sale_mode"
+)
+
+// Pod sale mode values.
+const (
+	PodSaleModeSpot      = "spot"
+	PodSaleModeScheduled = "scheduled"
+	PodSaleModeReserved  = "reserved"
+	PodSaleModeUnknown   = "unknown"
+)
+
 // PodAnnotationResourcePackageKey is a const variable for pod annotation about resource package name
 const (
 	PodAnnotationResourcePackageKey = "katalyst.kubewharf.io/resource_package"

--- a/pkg/consts/pod_test.go
+++ b/pkg/consts/pod_test.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package consts
+
+import (
+	"testing"
+)
+
+func TestPodSaleModeConstants(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]string{
+		"PodAnnotationSaleModeKey": PodAnnotationSaleModeKey,
+		"PodSaleModeSpot":          PodSaleModeSpot,
+		"PodSaleModeScheduled":     PodSaleModeScheduled,
+		"PodSaleModeReserved":      PodSaleModeReserved,
+		"PodSaleModeUnknown":       PodSaleModeUnknown,
+	}
+	wants := map[string]string{
+		"PodAnnotationSaleModeKey": "katalyst.kubewharf.io/sale_mode",
+		"PodSaleModeSpot":          "spot",
+		"PodSaleModeScheduled":     "scheduled",
+		"PodSaleModeReserved":      "reserved",
+		"PodSaleModeUnknown":       "unknown",
+	}
+
+	for name, got := range tests {
+		if got != wants[name] {
+			t.Errorf("%s = %q, want %q", name, got, wants[name])
+		}
+	}
+}


### PR DESCRIPTION
Expose shared pod sale mode annotation and value constants for downstream components.


#### What type of PR is this?

Features
#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### English

- Adds `PodAnnotationSaleModeKey` and shared pod sale-mode constants in `pkg/consts/pod.go`.
- Renames `PodSaleModeDefault` to `PodSaleModeUnknown` and changes its value from `"default"` to `"unknown"`.
- Extends `NumaEvictionRankingMetric` and `SystemEvictionRankingMetric` to allow `sale_mode.pod`.
- Consumers using `PodSaleModeDefault` or `"default"` must update.
- Downstream components can use `spot`, `scheduled`, `reserved`, and `unknown` for pod sale modes.
- Downstream configuration consumers can use `sale_mode.pod` in the affected ranking metrics.
- Adds unit tests in `pkg/consts/pod_test.go`.
- The `kubebuilder` markers changed. Regenerate CRD schemas when publishing generated API artifacts.

### 简体中文

- 在 `pkg/consts/pod.go` 中新增 `PodAnnotationSaleModeKey` 和共享的 pod sale-mode 常量。
- 将 `PodSaleModeDefault` 重命名为 `PodSaleModeUnknown`，并将其值从 `"default"` 修改为 `"unknown"`。
- 扩展 `NumaEvictionRankingMetric` 和 `SystemEvictionRankingMetric`，使其支持 `sale_mode.pod`。
- 使用 `PodSaleModeDefault` 或 `"default"` 的消费者必须更新。
- 下游组件可以使用 `spot`、`scheduled`、`reserved` 和 `unknown` 表示 pod sale mode。
- 下游配置消费者可以在受影响的 ranking metrics 中使用 `sale_mode.pod`。
- 在 `pkg/consts/pod_test.go` 中新增单元测试。
- `kubebuilder` markers 已变更。发布生成的 API artifacts 时需要重新生成 CRD schemas。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->